### PR TITLE
Add contributor information

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "Google Tag Manager"
   ],
   "author": "Carsten Lamm <carsten.lamm@holidaycheck.de>",
+  "contributors": [
+    "Alexander Schmidt <alexanderschmidt1@gmail.com>",
+    "Mathias Schreck <schreck.mathias@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/holidaycheck/react-google-tag-manager/issues"


### PR DESCRIPTION
Reading through the `package.json` file to search for a license definition I saw that there is no contributor information right now. This pull request adds that information (in alphabetical order).
