### PR TITLE
Allow scheme/protocol to be passed to script

### DIFF
--- a/src/build_parts.js
+++ b/src/build_parts.js
@@ -2,20 +2,20 @@ function convertToKeyValueString(obj) {
     return JSON.stringify(obj).slice(1, -1);
 }
 
-function buildParts({ id, dataLayerName = 'dataLayer', additionalEvents = {} }) {
+function buildParts({ id, dataLayerName = 'dataLayer', additionalEvents = {}, scheme = '' }) {
     if (id === undefined) {
         throw new Error('No GTM id provided');
     }
 
     const iframe = `
-        <iframe src="//www.googletagmanager.com/ns.html?id=${id}"
+        <iframe src="${scheme}//www.googletagmanager.com/ns.html?id=${id}"
             height="0" width="0" style="display:none;visibility:hidden"></iframe>`;
 
     const script = `
         (function(w,d,s,l,i){w[l]=w[l]||[];
             w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${convertToKeyValueString(additionalEvents)}});
             var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-            j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;
+            j.async=true;j.src='${scheme}//www.googletagmanager.com/gtm.js?id='+i+dl;
             f.parentNode.insertBefore(j,f);
         })(window,document,'script','${dataLayerName}','${id}');`;
 


### PR DESCRIPTION
Googles GTM now seems to redirect any http request to https, this now causes an extra redirect which seems wasteful.
This proposal is to allow someone to pass in the scheme they desire so someone can always call https if they want.
The alternative would be to always use https hardcoded in the scripts, however i'm not sure if people want that and would prefer to keep it as it currently sits.